### PR TITLE
fix: node-exporter port conflict.

### DIFF
--- a/prometheus/prometheus-stack-values.yaml
+++ b/prometheus/prometheus-stack-values.yaml
@@ -66,7 +66,7 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          accessModes: ["ReadWriteOnce"]
+          accessModes: ['ReadWriteOnce']
           resources:
             requests:
               storage: 20Gi
@@ -80,7 +80,6 @@ prometheus:
   additionalServiceMonitors: []
   additionalPodMonitors: []
 
-
 ## Configuration for thanosRuler
 ## ref: https://thanos.io/tip/components/rule.md/
 thanosRuler:
@@ -90,6 +89,3 @@ prometheus-node-exporter:
   service:
     port: 9101
     targetPort: 9101
-
-  extraArgs:
-    - --web.listen-address=:9101


### PR DESCRIPTION
specify 9101 means prometheus tries to bind to the same port twice

ts=2025-10-29T14:29:15.503Z caller=node_exporter.go:223 level=error err="listen tcp :9101: bind: address already in use"